### PR TITLE
feat(run): emit run metadata for stable latest/diff workflows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ __pycache__
 
 # Build artifacts
 dist/
+.tmp/
 output/*
 !output/example-mac.json
 *.exe

--- a/audit/linux/config.sh
+++ b/audit/linux/config.sh
@@ -275,6 +275,8 @@ config_main() {
     config_parse_args "$@"
     config_validate_and_resolve_paths
     config_prepare_files_and_common
+    source "$(dirname "${BASH_SOURCE[0]}")/lib/init.sh"
+    audit_set_run_meta_trap "config"
     config_write_report_header_if_needed
     config_init_ndjson_if_needed
     run_config_audit

--- a/audit/linux/execution.sh
+++ b/audit/linux/execution.sh
@@ -236,6 +236,8 @@ execution_main() {
     execution_parse_args "$@"
     execution_validate_and_resolve_paths
     execution_prepare_files_and_common
+    source "$(dirname "${BASH_SOURCE[0]}")/lib/init.sh"
+    audit_set_run_meta_trap "execution"
     execution_write_report_header_if_needed
     execution_init_ndjson_if_needed
     run_execution_audit

--- a/audit/linux/full-audit.sh
+++ b/audit/linux/full-audit.sh
@@ -105,6 +105,14 @@ while (($# > 0)); do
             NO_COLOR=true
             shift
             ;;
+        --run-meta-out)
+            if (($# < 2)); then
+                echo "Error: --run-meta-out requires a path" >&2
+                exit 1
+            fi
+            RUN_META_OUT="$2"
+            shift 2
+            ;;
         -h|--help)
             usage
             exit 0
@@ -127,6 +135,8 @@ if [[ ! "$OLD_FILE_DAYS" =~ ^[0-9]+$ ]]; then
     exit 1
 fi
 
+source "$(dirname "$0")/lib/init.sh"
+
 _ndjson_requested=$WRITE_NDJSON
 audit_resolve_output_paths "full-audit"
 # One shared probe-failure log across subshells (command substitutions)
@@ -148,6 +158,7 @@ TOP_PATHS_FILE="${TOP_PATHS_FILE:-$REPORT_DIR/.full-audit-top-paths-$TIMESTAMP_F
 : > "$PROBE_FAILURES_FILE"
 
 source "$(dirname "$0")/lib/common.sh"
+audit_set_run_meta_trap "full"
 
 echo -e "${BOLD}${CYAN}"
 echo "╔══════════════════════════════════════════════════╗"

--- a/audit/linux/identity.sh
+++ b/audit/linux/identity.sh
@@ -217,6 +217,8 @@ identity_main() {
     identity_parse_args "$@"
     identity_validate_and_resolve_paths
     identity_prepare_files_and_common
+    source "$(dirname "${BASH_SOURCE[0]}")/lib/init.sh"
+    audit_set_run_meta_trap "identity"
     identity_write_report_header_if_needed
     identity_init_ndjson_if_needed
     run_identity_audit

--- a/audit/linux/lib/init.sh
+++ b/audit/linux/lib/init.sh
@@ -109,6 +109,15 @@ audit_parse_args() {
                 NO_COLOR=true
                 shift
                 ;;
+            --run-meta-out)
+                if (($# < 2)); then
+                    _err "--run-meta-out requires a path"
+                    "$_usage_func"
+                    exit 1
+                fi
+                RUN_META_OUT="$2"
+                shift 2
+                ;;
             -h|--help)
                 "$_usage_func"
                 exit 0
@@ -145,6 +154,8 @@ audit_resolve_output_paths() {
         REPORT_FILE="$OUTPUT_FILE"
         REPORT_DIR=$(dirname "$REPORT_FILE")
     else
+        # Use timestamped run directory: output/<audit-id>-audit/<timestamp>/
+        REPORT_DIR="${REPORT_DIR:-$DEFAULT_REPORT_DIR}/$TIMESTAMP_FOR_FILENAME"
         REPORT_FILE="${REPORT_FILE:-$REPORT_DIR/${report_suffix}-$TIMESTAMP_FOR_FILENAME.md}"
     fi
 
@@ -164,6 +175,64 @@ audit_resolve_output_paths() {
         REDACT_PATHS=false
         NDJSON_FILE=""
     fi
+}
+
+# Sets EXIT trap to write run meta only on success. Chains with existing EXIT trap (e.g. _common_cleanup_tmps).
+# audit_write_run_meta must already be defined (init.sh already sourced).
+# Usage: audit_set_run_meta_trap <audit_id>
+audit_set_run_meta_trap() {
+    local id="$1"
+    local prev_trap prev_cmd
+    prev_trap=$(trap -p EXIT 2>/dev/null) || true
+    if [[ -n "$prev_trap" ]]; then
+        prev_cmd=$(echo "$prev_trap" | sed -n "s/^trap -- '\(.*\)' EXIT\$/\1/p" | sed "s/\\\\'/'/g") || true
+    fi
+    # Run our meta write first (if success), then chain to prev trap (e.g. cleanup). No explicit exit.
+    trap "ec=\$?; if [[ \$ec -eq 0 && -n \"\${RUN_META_OUT:-}\" ]]; then audit_write_run_meta \"$id\"; fi; ${prev_cmd:+$prev_cmd; }" EXIT
+}
+
+# Writes run metadata JSON to RUN_META_OUT if set. Only call on successful exit.
+# Usage: audit_write_run_meta <audit_id>
+audit_write_run_meta() {
+    [[ -n "${RUN_META_OUT:-}" ]] || return 0
+
+    local audit_id="${1:-}"
+    [[ -n "$audit_id" ]] || return 0
+
+    local platform="unknown"
+    if [[ "$(dirname "${BASH_SOURCE[0]:-.}")" == *"/linux/"* ]]; then
+        platform="linux"
+    elif [[ "$(dirname "${BASH_SOURCE[0]:-.}")" == *"/mac/"* ]]; then
+        platform="mac"
+    fi
+
+    # Make paths repo-relative (cmd.Dir=repoRoot so PWD=repoRoot)
+    _rel() {
+        local p="$1"
+        [[ -z "${PWD:-}" ]] && return
+        if [[ "$p" == "$PWD" ]]; then
+            echo "."
+        elif [[ "$p" == "$PWD"/* ]]; then
+            echo "${p#$PWD/}"
+        fi
+    }
+    local dir="$(_rel "$REPORT_DIR")"
+    [[ -z "$dir" ]] && dir="$REPORT_DIR"
+    local ndjson="$(_rel "${NDJSON_FILE:-}")"
+    [[ -z "$ndjson" ]] && ndjson="${NDJSON_FILE:-}"
+    local report="$(_rel "${REPORT_FILE:-}")"
+    [[ -z "$report" ]] && report="${REPORT_FILE:-}"
+
+    # JSON object, one line
+    printf '{"run_id":"%s","created_at":"%s","platform":"%s","audit_id":"%s","dir":"%s","ndjson":"%s","report":"%s"}\n' \
+        "$(printf '%s' "$RUN_ID" | sed 's/\\/\\\\/g; s/"/\\"/g')" \
+        "$(printf '%s' "${ISO_TIMESTAMP:-}" | sed 's/\\/\\\\/g; s/"/\\"/g')" \
+        "$(printf '%s' "$platform" | sed 's/\\/\\\\/g; s/"/\\"/g')" \
+        "$(printf '%s' "$audit_id" | sed 's/\\/\\\\/g; s/"/\\"/g')" \
+        "$(printf '%s' "$dir" | sed 's/\\/\\\\/g; s/"/\\"/g')" \
+        "$(printf '%s' "$ndjson" | sed 's/\\/\\\\/g; s/"/\\"/g')" \
+        "$(printf '%s' "$report" | sed 's/\\/\\\\/g; s/"/\\"/g')" \
+        > "$RUN_META_OUT"
 }
 
 export AUDIT_INIT_LOADED=1

--- a/audit/linux/network.sh
+++ b/audit/linux/network.sh
@@ -277,6 +277,8 @@ network_main() {
     network_parse_args "$@"
     network_validate_and_resolve_paths
     network_prepare_files_and_common
+    source "$(dirname "${BASH_SOURCE[0]}")/lib/init.sh"
+    audit_set_run_meta_trap "network"
     network_write_report_header_if_needed
     network_init_ndjson_if_needed
     run_network_audit

--- a/audit/linux/persistence.sh
+++ b/audit/linux/persistence.sh
@@ -295,6 +295,8 @@ persistence_main() {
     persistence_parse_args "$@"
     persistence_validate_and_resolve_paths
     persistence_prepare_files_and_common
+    source "$(dirname "${BASH_SOURCE[0]}")/lib/init.sh"
+    audit_set_run_meta_trap "persistence"
     persistence_write_report_header_if_needed
     persistence_init_ndjson_if_needed
     run_persistence_audit

--- a/audit/linux/storage.sh
+++ b/audit/linux/storage.sh
@@ -313,6 +313,8 @@ storage_main() {
     storage_validate_and_resolve_paths
     storage_build_scan_roots
     storage_prepare_files_and_common
+    source "$(dirname "${BASH_SOURCE[0]}")/lib/init.sh"
+    audit_set_run_meta_trap "storage"
     storage_write_report_header_if_needed
     storage_init_ndjson_if_needed
     run_storage_audit

--- a/audit/mac/config.sh
+++ b/audit/mac/config.sh
@@ -185,6 +185,8 @@ config_main() {
     config_parse_args "$@"
     config_validate_and_resolve_paths
     config_prepare_files_and_common
+    source "$(dirname "${BASH_SOURCE[0]}")/lib/init.sh"
+    audit_set_run_meta_trap "config"
     config_write_report_header_if_needed
     config_init_ndjson_if_needed
     run_config_audit

--- a/audit/mac/execution.sh
+++ b/audit/mac/execution.sh
@@ -189,6 +189,8 @@ execution_main() {
     execution_parse_args "$@"
     execution_validate_and_resolve_paths
     execution_prepare_files_and_common
+    source "$(dirname "${BASH_SOURCE[0]}")/lib/init.sh"
+    audit_set_run_meta_trap "execution"
     execution_write_report_header_if_needed
     execution_init_ndjson_if_needed
     run_execution_audit

--- a/audit/mac/full-audit.sh
+++ b/audit/mac/full-audit.sh
@@ -105,6 +105,14 @@ while (($# > 0)); do
             NO_COLOR=true
             shift
             ;;
+        --run-meta-out)
+            if (($# < 2)); then
+                echo "Error: --run-meta-out requires a path" >&2
+                exit 1
+            fi
+            RUN_META_OUT="$2"
+            shift 2
+            ;;
         -h|--help)
             usage
             exit 0
@@ -127,6 +135,8 @@ if [[ ! "$OLD_FILE_DAYS" =~ ^[0-9]+$ ]]; then
     exit 1
 fi
 
+source "$(dirname "$0")/lib/init.sh"
+
 _ndjson_requested=$WRITE_NDJSON
 audit_resolve_output_paths "full-audit"
 # One shared probe-failure log across subshells (command substitutions)
@@ -148,6 +158,7 @@ TOP_PATHS_FILE="${TOP_PATHS_FILE:-$REPORT_DIR/.full-audit-top-paths-$TIMESTAMP_F
 : > "$PROBE_FAILURES_FILE"
 
 source "$(dirname "$0")/lib/common.sh"
+audit_set_run_meta_trap "full"
 
 echo -e "${BOLD}${CYAN}"
 echo "╔══════════════════════════════════════════════════╗"

--- a/audit/mac/identity.sh
+++ b/audit/mac/identity.sh
@@ -200,6 +200,8 @@ identity_main() {
     identity_parse_args "$@"
     identity_validate_and_resolve_paths
     identity_prepare_files_and_common
+    source "$(dirname "${BASH_SOURCE[0]}")/lib/init.sh"
+    audit_set_run_meta_trap "identity"
     identity_write_report_header_if_needed
     identity_init_ndjson_if_needed
     run_identity_audit

--- a/audit/mac/lib/init.sh
+++ b/audit/mac/lib/init.sh
@@ -109,6 +109,15 @@ audit_parse_args() {
                 NO_COLOR=true
                 shift
                 ;;
+            --run-meta-out)
+                if (($# < 2)); then
+                    _err "--run-meta-out requires a path"
+                    "$_usage_func"
+                    exit 1
+                fi
+                RUN_META_OUT="$2"
+                shift 2
+                ;;
             -h|--help)
                 "$_usage_func"
                 exit 0
@@ -145,6 +154,8 @@ audit_resolve_output_paths() {
         REPORT_FILE="$OUTPUT_FILE"
         REPORT_DIR=$(dirname "$REPORT_FILE")
     else
+        # Use timestamped run directory: output/<audit-id>-audit/<timestamp>/
+        REPORT_DIR="${REPORT_DIR:-$DEFAULT_REPORT_DIR}/$TIMESTAMP_FOR_FILENAME"
         REPORT_FILE="${REPORT_FILE:-$REPORT_DIR/${report_suffix}-$TIMESTAMP_FOR_FILENAME.md}"
     fi
 
@@ -164,6 +175,64 @@ audit_resolve_output_paths() {
         REDACT_PATHS=false
         NDJSON_FILE=""
     fi
+}
+
+# Sets EXIT trap to write run meta only on success. Chains with existing EXIT trap (e.g. _common_cleanup_tmps).
+# audit_write_run_meta must already be defined (init.sh already sourced).
+# Usage: audit_set_run_meta_trap <audit_id>
+audit_set_run_meta_trap() {
+    local id="$1"
+    local prev_trap prev_cmd
+    prev_trap=$(trap -p EXIT 2>/dev/null) || true
+    if [[ -n "$prev_trap" ]]; then
+        prev_cmd=$(echo "$prev_trap" | sed -n "s/^trap -- '\(.*\)' EXIT\$/\1/p" | sed "s/\\\\'/'/g") || true
+    fi
+    # Run our meta write first (if success), then chain to prev trap (e.g. cleanup). No explicit exit.
+    trap "ec=\$?; if [[ \$ec -eq 0 && -n \"\${RUN_META_OUT:-}\" ]]; then audit_write_run_meta \"$id\"; fi; ${prev_cmd:+$prev_cmd; }" EXIT
+}
+
+# Writes run metadata JSON to RUN_META_OUT if set. Only call on successful exit.
+# Usage: audit_write_run_meta <audit_id>
+audit_write_run_meta() {
+    [[ -n "${RUN_META_OUT:-}" ]] || return 0
+
+    local audit_id="${1:-}"
+    [[ -n "$audit_id" ]] || return 0
+
+    local platform="unknown"
+    if [[ "$(dirname "${BASH_SOURCE[0]:-.}")" == *"/linux/"* ]]; then
+        platform="linux"
+    elif [[ "$(dirname "${BASH_SOURCE[0]:-.}")" == *"/mac/"* ]]; then
+        platform="mac"
+    fi
+
+    # Make paths repo-relative (cmd.Dir=repoRoot so PWD=repoRoot)
+    _rel() {
+        local p="$1"
+        [[ -z "${PWD:-}" ]] && return
+        if [[ "$p" == "$PWD" ]]; then
+            echo "."
+        elif [[ "$p" == "$PWD"/* ]]; then
+            echo "${p#$PWD/}"
+        fi
+    }
+    local dir="$(_rel "$REPORT_DIR")"
+    [[ -z "$dir" ]] && dir="$REPORT_DIR"
+    local ndjson="$(_rel "${NDJSON_FILE:-}")"
+    [[ -z "$ndjson" ]] && ndjson="${NDJSON_FILE:-}"
+    local report="$(_rel "${REPORT_FILE:-}")"
+    [[ -z "$report" ]] && report="${REPORT_FILE:-}"
+
+    # JSON object, one line
+    printf '{"run_id":"%s","created_at":"%s","platform":"%s","audit_id":"%s","dir":"%s","ndjson":"%s","report":"%s"}\n' \
+        "$(printf '%s' "$RUN_ID" | sed 's/\\/\\\\/g; s/"/\\"/g')" \
+        "$(printf '%s' "${ISO_TIMESTAMP:-}" | sed 's/\\/\\\\/g; s/"/\\"/g')" \
+        "$(printf '%s' "$platform" | sed 's/\\/\\\\/g; s/"/\\"/g')" \
+        "$(printf '%s' "$audit_id" | sed 's/\\/\\\\/g; s/"/\\"/g')" \
+        "$(printf '%s' "$dir" | sed 's/\\/\\\\/g; s/"/\\"/g')" \
+        "$(printf '%s' "$ndjson" | sed 's/\\/\\\\/g; s/"/\\"/g')" \
+        "$(printf '%s' "$report" | sed 's/\\/\\\\/g; s/"/\\"/g')" \
+        > "$RUN_META_OUT"
 }
 
 export AUDIT_INIT_LOADED=1

--- a/audit/mac/network.sh
+++ b/audit/mac/network.sh
@@ -214,6 +214,8 @@ network_main() {
     network_parse_args "$@"
     network_validate_and_resolve_paths
     network_prepare_files_and_common
+    source "$(dirname "${BASH_SOURCE[0]}")/lib/init.sh"
+    audit_set_run_meta_trap "network"
     network_write_report_header_if_needed
     network_init_ndjson_if_needed
     run_network_audit

--- a/audit/mac/persistence.sh
+++ b/audit/mac/persistence.sh
@@ -216,6 +216,8 @@ persistence_main() {
     persistence_parse_args "$@"
     persistence_validate_and_resolve_paths
     persistence_prepare_files_and_common
+    source "$(dirname "${BASH_SOURCE[0]}")/lib/init.sh"
+    audit_set_run_meta_trap "persistence"
     persistence_write_report_header_if_needed
     persistence_init_ndjson_if_needed
     run_persistence_audit

--- a/audit/mac/storage.sh
+++ b/audit/mac/storage.sh
@@ -313,6 +313,8 @@ storage_main() {
     storage_validate_and_resolve_paths
     storage_build_scan_roots
     storage_prepare_files_and_common
+    source "$(dirname "${BASH_SOURCE[0]}")/lib/init.sh"
+    audit_set_run_meta_trap "storage"
     storage_write_report_header_if_needed
     storage_init_ndjson_if_needed
     run_storage_audit

--- a/cmd/osaudit/main.go
+++ b/cmd/osaudit/main.go
@@ -351,7 +351,7 @@ func runMenu(commands []auditCommand, detectedOS, repoRoot string) {
 
 		selected := commands[choice-1]
 		fmt.Printf("\nRunning: %s\n\n", selected.Display)
-		if code, err := runAuditCommand(repoRoot, selected, nil); err != nil {
+		if code, err := runAuditCommand(repoRoot, selected, nil, false); err != nil {
 			fmt.Printf("Command failed (exit %d): %v\n", code, err)
 		}
 
@@ -404,7 +404,7 @@ func promptRunAgain(reader *bufio.Reader) (bool, bool) {
 	return answer == "y" || answer == "yes", true
 }
 
-func runAuditCommand(repoRoot string, command auditCommand, passthrough []string) (int, error) {
+func runAuditCommand(repoRoot string, command auditCommand, passthrough []string, printRunMeta bool) (int, error) {
 	targetPath, err := resolveCommandPath(repoRoot, command.Exec[0])
 	if err != nil {
 		return 1, err
@@ -413,18 +413,44 @@ func runAuditCommand(repoRoot string, command auditCommand, passthrough []string
 	args := append([]string{}, command.Exec[1:]...)
 	args = append(args, passthrough...)
 
+	var runMetaPath string
+	if printRunMeta {
+		tmpDir := filepath.Join(repoRoot, ".tmp")
+		_ = os.MkdirAll(tmpDir, 0o755)
+		f, err := os.CreateTemp(tmpDir, "osaudit-run-meta-*.json")
+		if err != nil {
+			return 1, fmt.Errorf("create temp file for run meta: %w", err)
+		}
+		runMetaPath = f.Name()
+		f.Close()
+		args = append(args, "--run-meta-out", runMetaPath)
+		defer os.Remove(runMetaPath)
+	}
+
 	cmd := exec.Command(targetPath, args...)
-	cmd.Stdout = os.Stdout
+	if printRunMeta {
+		cmd.Stdout = os.Stderr // human output to stderr so stdout stays clean for JSON
+	} else {
+		cmd.Stdout = os.Stdout
+	}
 	cmd.Stderr = os.Stderr
 	cmd.Stdin = os.Stdin
 	cmd.Dir = repoRoot
 	cmd.Env = append(os.Environ(), "OSAUDIT_ROOT="+repoRoot)
 
 	err = cmd.Run()
-	if err == nil {
-		return 0, nil
+	if err != nil {
+		return exitCodeFromError(err), err
 	}
-	return exitCodeFromError(err), err
+
+	if printRunMeta && runMetaPath != "" {
+		data, err := os.ReadFile(runMetaPath)
+		if err != nil {
+			return 1, fmt.Errorf("read run meta: %w", err)
+		}
+		fmt.Println(string(data))
+	}
+	return 0, nil
 }
 
 func resolveCommandPath(repoRoot, manifestPath string) (string, error) {
@@ -444,7 +470,7 @@ func resolveCommandPath(repoRoot, manifestPath string) (string, error) {
 }
 
 func runSubcommand(commands []auditCommand, repoRoot string, args []string) int {
-	id, passthrough, err := parseRunArgs(args)
+	id, passthrough, printRunMeta, err := parseRunArgs(args)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		printUsage()
@@ -457,26 +483,30 @@ func runSubcommand(commands []auditCommand, repoRoot string, args []string) int 
 		return 2
 	}
 
-	code, runErr := runAuditCommand(repoRoot, command, passthrough)
+	code, runErr := runAuditCommand(repoRoot, command, passthrough, printRunMeta)
 	if runErr != nil {
 		return code
 	}
 	return 0
 }
 
-func parseRunArgs(args []string) (string, []string, error) {
+func parseRunArgs(args []string) (id string, passthrough []string, printRunMeta bool, err error) {
 	if len(args) == 0 {
-		return "", nil, errors.New("missing command id for 'run'")
+		return "", nil, false, errors.New("missing command id for 'run'")
 	}
-	id := args[0]
-
-	if len(args) == 1 {
-		return id, nil, nil
+	id = args[0]
+	i := 1
+	for i < len(args) && args[i] == "--print-run-meta" {
+		printRunMeta = true
+		i++
 	}
-	if args[1] != "--" {
-		return "", nil, errors.New("pass-through arguments must be after '--'")
+	if i >= len(args) {
+		return id, nil, printRunMeta, nil
 	}
-	return id, args[2:], nil
+	if args[i] != "--" {
+		return "", nil, false, errors.New("pass-through arguments must be after '--'")
+	}
+	return id, args[i+1:], printRunMeta, nil
 }
 
 func findCommandByID(commands []auditCommand, id string) (auditCommand, error) {
@@ -535,7 +565,7 @@ func printUsage() {
 	fmt.Fprintln(os.Stderr, "Usage:")
 	fmt.Fprintln(os.Stderr, "  osaudit")
 	fmt.Fprintln(os.Stderr, "  osaudit list")
-	fmt.Fprintln(os.Stderr, "  osaudit run <id> -- [args...]")
+	fmt.Fprintln(os.Stderr, "  osaudit run <id> [--print-run-meta] -- [args...]")
 	fmt.Fprintln(os.Stderr, "  osaudit diff --baseline <path> --current <path> [--ndjson]")
 }
 

--- a/cmd/osaudit/main_test.go
+++ b/cmd/osaudit/main_test.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"encoding/json"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -113,24 +115,27 @@ func TestValidateManifest(t *testing.T) {
 
 func TestParseRunArgs(t *testing.T) {
 	tests := []struct {
-		name       string
-		args       []string
-		wantID     string
-		wantPass   []string
-		wantErr    bool
-		wantErrMsg string
+		name         string
+		args         []string
+		wantID       string
+		wantPass     []string
+		wantPrintMeta bool
+		wantErr      bool
+		wantErrMsg   string
 	}{
-		{"no args (error)", []string{}, "", nil, true, "missing command id"},
-		{"id only", []string{"full"}, "full", nil, false, ""},
-		{"id + -- + passthrough", []string{"full", "--", "-x", "y"}, "full", []string{"-x", "y"}, false, ""},
-		{"id + extra without -- (error)", []string{"full", "extra"}, "", nil, true, "pass-through"},
+		{"no args (error)", []string{}, "", nil, false, true, "missing command id"},
+		{"id only", []string{"full"}, "full", nil, false, false, ""},
+		{"id + -- + passthrough", []string{"full", "--", "-x", "y"}, "full", []string{"-x", "y"}, false, false, ""},
+		{"id + --print-run-meta", []string{"full", "--print-run-meta"}, "full", nil, true, false, ""},
+		{"id + --print-run-meta + -- + passthrough", []string{"full", "--print-run-meta", "--", "-x"}, "full", []string{"-x"}, true, false, ""},
+		{"id + extra without -- (error)", []string{"full", "extra"}, "", nil, false, true, "pass-through"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			id, pass, err := parseRunArgs(tt.args)
+			id, pass, printMeta, err := parseRunArgs(tt.args)
 			if tt.wantErr {
 				if err == nil {
-					t.Fatalf("parseRunArgs() = %q, %v, nil; want error containing %q", id, pass, tt.wantErrMsg)
+					t.Fatalf("parseRunArgs() = %q, %v, %v, nil; want error containing %q", id, pass, printMeta, tt.wantErrMsg)
 				}
 				if !strings.Contains(err.Error(), tt.wantErrMsg) {
 					t.Errorf("parseRunArgs() error = %v, want containing %q", err, tt.wantErrMsg)
@@ -146,6 +151,9 @@ func TestParseRunArgs(t *testing.T) {
 			}
 			if !sliceEqual(pass, tt.wantPass) {
 				t.Errorf("parseRunArgs() passthrough = %v, want %v", pass, tt.wantPass)
+			}
+			if printMeta != tt.wantPrintMeta {
+				t.Errorf("parseRunArgs() printMeta = %v, want %v", printMeta, tt.wantPrintMeta)
 			}
 		})
 	}
@@ -321,5 +329,101 @@ func TestResolveRepoRoot_FallbackToExtraction(t *testing.T) {
 	if extractedCleanup != nil {
 		extractedCleanup()
 		extractedCleanup = nil
+	}
+}
+
+// TestRunPrintRunMeta outputs valid JSON on stdout and logs on stderr.
+func TestRunPrintRunMeta(t *testing.T) {
+	if runtime.GOOS != "linux" && runtime.GOOS != "darwin" {
+		t.Skip("audit scripts only exist for linux/mac")
+	}
+	// Use module root (where go.mod lives) so dist/osaudit is found when built from repo
+	cwd, _ := os.Getwd()
+	for d := cwd; d != ""; d = filepath.Dir(d) {
+		if _, err := os.Stat(filepath.Join(d, "go.mod")); err == nil {
+			cwd = d
+			break
+		}
+	}
+	root := cwd
+	bin := filepath.Join(root, "dist", "osaudit")
+	if _, err := os.Stat(bin); err != nil {
+		t.Skipf("dist/osaudit not built: %v (run: go build -o dist/osaudit ./cmd/osaudit)", err)
+	}
+
+	cmd := exec.Command(bin, "run", "execution", "--print-run-meta", "--", "--ndjson", "--redact-all")
+	cmd.Dir = root
+	cmd.Env = append(os.Environ(), "OSAUDIT_ROOT="+root)
+	var stdout, stderr strings.Builder
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	if err != nil {
+		t.Fatalf("run failed: %v\nstderr: %s", err, stderr.String())
+	}
+
+	out := strings.TrimSpace(stdout.String())
+	if out == "" {
+		t.Fatal("stdout empty; expected JSON")
+	}
+	if stderr.Len() == 0 {
+		t.Error("stderr empty; expected logs")
+	}
+
+	var meta struct {
+		RunID     string `json:"run_id"`
+		CreatedAt string `json:"created_at"`
+		Platform  string `json:"platform"`
+		AuditID   string `json:"audit_id"`
+		Dir       string `json:"dir"`
+		NDJSON    string `json:"ndjson"`
+		Report    string `json:"report"`
+	}
+	if err := json.Unmarshal([]byte(out), &meta); err != nil {
+		t.Fatalf("stdout not valid JSON: %v\nraw: %s", err, out)
+	}
+	if meta.AuditID != "execution" {
+		t.Errorf("audit_id = %q, want execution", meta.AuditID)
+	}
+	if meta.Platform != "linux" && meta.Platform != "mac" {
+		t.Errorf("platform = %q, want linux or mac", meta.Platform)
+	}
+	// dir should be timestamped: output/execution-audit/YYYYMMDD-HHMMSS
+	if !strings.Contains(meta.Dir, "output/execution-audit/") {
+		t.Errorf("dir = %q, want output/execution-audit/<timestamp>", meta.Dir)
+	}
+}
+
+// TestRunPrintRunMeta_NoJSONOnFailure verifies no JSON is printed when script fails.
+func TestRunPrintRunMeta_NoJSONOnFailure(t *testing.T) {
+	if runtime.GOOS != "linux" && runtime.GOOS != "darwin" {
+		t.Skip("audit scripts only exist for linux/mac")
+	}
+	cwd, _ := os.Getwd()
+	for d := cwd; d != ""; d = filepath.Dir(d) {
+		if _, err := os.Stat(filepath.Join(d, "go.mod")); err == nil {
+			cwd = d
+			break
+		}
+	}
+	bin := filepath.Join(cwd, "dist", "osaudit")
+	if _, err := os.Stat(bin); err != nil {
+		t.Skipf("dist/osaudit not built: %v", err)
+	}
+
+	// Use unknown command id so run fails before script executes
+	cmd := exec.Command(bin, "run", "nonexistent-id", "--print-run-meta", "--", "--ndjson")
+	cmd.Dir = cwd
+	cmd.Env = append(os.Environ(), "OSAUDIT_ROOT="+cwd)
+	var stdout strings.Builder
+	cmd.Stdout = &stdout
+	cmd.Stderr = nil
+
+	_ = cmd.Run() // expect non-zero exit
+
+	out := strings.TrimSpace(stdout.String())
+	if out != "" {
+		t.Errorf("stdout should be empty on failure, got: %s", out)
 	}
 }

--- a/internal/latest/manifest.go
+++ b/internal/latest/manifest.go
@@ -1,0 +1,40 @@
+package latest
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+)
+
+// RunMeta holds metadata for a single audit run, emitted by scripts and consumed by the scheduler.
+type RunMeta struct {
+	RunID     string `json:"run_id"`
+	CreatedAt string `json:"created_at"`
+	Platform  string `json:"platform"`
+	AuditID   string `json:"audit_id"`
+	Dir       string `json:"dir"`
+	NDJSON    string `json:"ndjson"`
+	Report    string `json:"report"`
+}
+
+// WriteLatestManifest writes a "latest" manifest for the given audit ID.
+// The manifest is written atomically (tmp write + rename) to meta.Dir/.latest.json.
+func WriteLatestManifest(auditID string, meta RunMeta) error {
+	if auditID == "" || meta.Dir == "" {
+		return nil
+	}
+	manifestPath := filepath.Join(meta.Dir, ".latest.json")
+	dir := filepath.Dir(manifestPath)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	data, err := json.Marshal(meta)
+	if err != nil {
+		return err
+	}
+	tmpPath := manifestPath + ".tmp"
+	if err := os.WriteFile(tmpPath, data, 0o644); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, manifestPath)
+}


### PR DESCRIPTION
- Add --print-run-meta and --run-meta-out plumbing
- Write run meta JSON only on success (EXIT trap)
- Ensure dir points to timestamped run directory
- Add internal/latest manifest writer + tests
- Use repoRoot/.tmp for sandbox-friendly temp files

Closes #18